### PR TITLE
Use ContainerUser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ RUN ["powershell", "C:/SHIR/build.ps1"]
 
 CMD ["powershell", "C:/SHIR/setup.ps1"]
 
+RUN net localgroup "Administrators" "User Manager\ContainerUser" /add
+
+USER ContainerUser
+
 ENV SHIR_WINDOWS_CONTAINER_ENV True
 
 HEALTHCHECK --start-period=120s CMD ["powershell", "C:/SHIR/health-check.ps1"]


### PR DESCRIPTION
Sets Dockerfile default user to the standard ContainerUser.
Need to add to Administrators group in order to have the permissions to run the SHIR.
However less exposed permissions than ContainerAdministrator I believe, which in turn has less than a full on Administrator user.