### PR TITLE
2022 Servercore image for upcoming AKS update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
 # Download the latest self-hosted integration runtime installer into the SHIR folder
 COPY SHIR C:/SHIR/

--- a/azure-pipelines-scheduled.yml
+++ b/azure-pipelines-scheduled.yml
@@ -75,7 +75,7 @@ stages:
               repo_sha=$(git rev-parse --verify HEAD)
               docker_image_tag_sha=${repo_sha:0:7}
               last_commit_time=$(date +'%Y%m%d%H%M%S')
-              echo "##vso[task.setvariable variable=DOCKER_TAG;isOutput=true]2022-${docker_image_tag_sha}-${last_commit_time}"
+              echo "##vso[task.setvariable variable=DOCKER_TAG;isOutput=true]${docker_image_tag_sha}-${last_commit_time}"
             displayName: 'Get Docker Tag'
             name: 'getDockerTag'
           - task: Docker@1

--- a/azure-pipelines-scheduled.yml
+++ b/azure-pipelines-scheduled.yml
@@ -12,7 +12,7 @@ trigger: none
 pr: none
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-2022'
 
 parameters:
   - name: enabled
@@ -75,7 +75,7 @@ stages:
               repo_sha=$(git rev-parse --verify HEAD)
               docker_image_tag_sha=${repo_sha:0:7}
               last_commit_time=$(date +'%Y%m%d%H%M%S')
-              echo "##vso[task.setvariable variable=DOCKER_TAG;isOutput=true]${docker_image_tag_sha}-${last_commit_time}"
+              echo "##vso[task.setvariable variable=DOCKER_TAG;isOutput=true]2022-${docker_image_tag_sha}-${last_commit_time}"
             displayName: 'Get Docker Tag'
             name: 'getDockerTag'
           - task: Docker@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ stages:
               repo_sha=$(git rev-parse --verify HEAD)
               docker_image_tag_sha=${repo_sha:0:7}
               last_commit_time=$(git log -1 --pretty='%cd' --date=iso | tr -d '+[:space:]:-' | head -c 14)
-              echo "##vso[task.setvariable variable=DOCKER_TAG;isOutput=true]${docker_image_tag_sha}-${last_commit_time}"
+              echo "##vso[task.setvariable variable=DOCKER_TAG;isOutput=true]2022-${docker_image_tag_sha}-${last_commit_time}"
             displayName: 'Get Docker Tag'
             name: 'getDockerTag'
           - task: Docker@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
   - master
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-2022'
 
 parameters:
   - name: pushImage
@@ -47,7 +47,7 @@ stages:
               repo_sha=$(git rev-parse --verify HEAD)
               docker_image_tag_sha=${repo_sha:0:7}
               last_commit_time=$(git log -1 --pretty='%cd' --date=iso | tr -d '+[:space:]:-' | head -c 14)
-              echo "##vso[task.setvariable variable=DOCKER_TAG;isOutput=true]${docker_image_tag_sha}-${last_commit_time}"
+              echo "##vso[task.setvariable variable=DOCKER_TAG;isOutput=true]2022-${docker_image_tag_sha}-${last_commit_time}"
             displayName: 'Get Docker Tag'
             name: 'getDockerTag'
           - task: Docker@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ stages:
               repo_sha=$(git rev-parse --verify HEAD)
               docker_image_tag_sha=${repo_sha:0:7}
               last_commit_time=$(git log -1 --pretty='%cd' --date=iso | tr -d '+[:space:]:-' | head -c 14)
-              echo "##vso[task.setvariable variable=DOCKER_TAG;isOutput=true]2022-${docker_image_tag_sha}-${last_commit_time}"
+              echo "##vso[task.setvariable variable=DOCKER_TAG;isOutput=true]${docker_image_tag_sha}-${last_commit_time}"
             displayName: 'Get Docker Tag'
             name: 'getDockerTag'
           - task: Docker@1


### PR DESCRIPTION
DO NOT MERGE

Updates the SHIR base OS to Windows 2022, as Windows 2019 will be deprecated in the future. This version is reliant on the AKS node version.