### PR TITLE
Updated with optional args and features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2022
+ARG INSTALL_JDK=true
+ARG INSTALL_LEGACY_JDK=false
+ARG INSTALL_NET_FRAMEWORK=true
+ARG INSTALL_CERT=true
+ARG ADD_MONITOR_USERS=true
+ARG SETUP_ENV=false
+ARG SHIR_FIX_VERSION=5.65.9593.1
 
 # Download the latest self-hosted integration runtime installer into the SHIR folder
 COPY SHIR C:/SHIR/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Support SHIR version: 5.0 or later
 
 For more information about Azure Data Factory, see [https://docs.microsoft.com/en-us/azure/data-factory/concepts-integration-runtime](https://docs.microsoft.com/en-us/azure/data-factory/concepts-integration-runtime)
 
+| Argument | Default Value | Description |
+|---|---|---|
+| INSTALL_JDK | true | Installs the Microsoft JDK 21 dependency. |
+| INSTALL_LEGACY_JDK | false | Installs the Adopt Open JDK 17 dependency. This is already a fallback on INSTALL_JDK so does not need setting if that is set to true. |
+| INSTALL_NET_FRAMEWORK | true | Installs the .NET Framework |
+| INSTALL_CERT | true | Installs MS Certs |
+| ADD_MONITOR_USERS | true | Adds Monitor Users |
+| SETUP_ENV | false | Performs basic env changes such as stopping auto update. Not tested. |
+| SHIR_FIX_VERSION | 5.65.9593.1 | If set, instead of using the download dynamic link and minimum version checking, will try to download the exact specified fix version. |
 
 # Contributing
 

--- a/SHIR/build.ps1
+++ b/SHIR/build.ps1
@@ -9,6 +9,7 @@ function Get-Remote-SHIR() {
     $MinimumVersion = [Version]'5.48.9106.2'
     if ($env:SHIR_FIX_VERSION -and $env:SHIR_FIX_VERSION.Trim() -ne '') { 
         $FixedVersion = $env:SHIR_FIX_VERSION.Trim()
+        Write-Output "SHIR FIX VERSION set to: $FixedVersion"
         $DownloadURL = "https://download.microsoft.com/download/E/4/7/E4771905-1079-445B-8BF9-8A1A075D8A10/IntegrationRuntime_$FixedVersion.msi"
     } else { 
         $FixedVersionURL = "https://download.microsoft.com/download/E/4/7/E4771905-1079-445B-8BF9-8A1A075D8A10/IntegrationRuntime_$MinimumVersion.msi"

--- a/SHIR/build.ps1
+++ b/SHIR/build.ps1
@@ -4,40 +4,43 @@ $DmgcmdPath = "C:\Program Files\Microsoft Integration Runtime\5.0\Shared\dmgcmd.
 $MsiFileName = 'IntegrationRuntime.latest.msi'
 
 function Get-Remote-SHIR() {
-  Write-Log "Downloading latest version of SHIR MSI file"
-
-  $MinimunVersion = [Version]'5.48.9106.2'
-  $FixedVersionURL = 'https://download.microsoft.com/download/E/4/7/E4771905-1079-445B-8BF9-8A1A075D8A10/IntegrationRuntime_5.48.9106.2.msi'
-  $DownloadURL = 'https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409'
-  try{
-    $Response = Invoke-WebRequest -Uri $DownloadURL -Method Get -UseBasicParsing -MaximumRedirection 0
-  } catch {
-    #  ignore the error
-  }
-
-  $RedirectURL = [string]$Response.Headers['Location']
-  Write-Output "Redirect URL: $RedirectURL"
-  if ($RedirectURL -match 'IntegrationRuntime_(\d+\.\d+\.\d+\.\d+)') {
-    if ($matches.Count -gt 1) {
-      $ExtractedVersion = [Version]$matches[1]
-      Write-Output "Dynamic download Version: $ExtractedVersion"
-    }
-  } else {
-    Write-Output "Version number not found in the URL"
-  }
+    Write-Log "Downloading latest version of SHIR MSI file"
   
-
-  # Compare the versions
-  if ($null -eq $ExtractedVersion -or $ExtractedVersion -lt $MinimunVersion) {
-      Write-Output "The extracted version ($ExtractedVersion) is lower than $MinimunVersion. Using minimum version URL."
-      $DownloadURL = $FixedVersionURL
-  }
-
-
-  # Temporarily disable progress updates to speed up the download process. (See https://stackoverflow.com/questions/69942663/invoke-webrequest-progress-becomes-irresponsive-paused-while-downloading-the-fil)
-  $ProgressPreference = 'SilentlyContinue'
-  Invoke-WebRequest -Uri $DownloadURL -OutFile "C:\SHIR\$MsiFileName"
-  $ProgressPreference = 'Continue'
+    $MinimumVersion = [Version]'5.48.9106.2'
+    if ($env:SHIR_FIX_VERSION -and $env:SHIR_FIX_VERSION.Trim() -ne '') { 
+        $FixedVersion = $env:SHIR_FIX_VERSION.Trim()
+        $DownloadURL = "https://download.microsoft.com/download/E/4/7/E4771905-1079-445B-8BF9-8A1A075D8A10/IntegrationRuntime_$FixedVersion.msi"
+    } else { 
+        $FixedVersionURL = "https://download.microsoft.com/download/E/4/7/E4771905-1079-445B-8BF9-8A1A075D8A10/IntegrationRuntime_$MinimumVersion.msi"
+        $DownloadURL = 'https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409'
+        try{
+          $Response = Invoke-WebRequest -Uri $DownloadURL -Method Get -UseBasicParsing -MaximumRedirection 2
+        } catch {
+          #  ignore the error
+        }
+      
+        $RedirectURL = [string]$Response.Headers['Location']
+        Write-Output "Redirect URL: $RedirectURL"
+        if ($RedirectURL -match 'IntegrationRuntime_(\d+\.\d+\.\d+\.\d+)') {
+          if ($matches.Count -gt 1) {
+            $ExtractedVersion = [Version]$matches[1]
+            Write-Output "Dynamic download Version: $ExtractedVersion"
+          }
+        } else {
+          Write-Output "Version number not found in the URL"
+        }
+        
+        # Compare the versions
+        if ($null -eq $ExtractedVersion -or $ExtractedVersion -lt $MinimumVersion) {
+            Write-Output "The extracted version ($ExtractedVersion) is lower than $MinimumVersion. Using minimum version URL."
+            $DownloadURL = $FixedVersionURL
+        }
+    }
+    
+    # Temporarily disable progress updates to speed up the download process. (See https://stackoverflow.com/questions/69942663/invoke-webrequest-progress-becomes-irresponsive-paused-while-downloading-the-fil)
+    $ProgressPreference = 'SilentlyContinue'
+    Invoke-WebRequest -Uri $DownloadURL -OutFile "C:\SHIR\$MsiFileName"
+    $ProgressPreference = 'Continue'
 }
 
 function Install-SHIR() {
@@ -63,12 +66,69 @@ function Install-SHIR() {
     Write-Log "SHIR MSI Install Successfully"
 }
 
+# From https://github.com/Azure/Azure-Data-Factory-Integration-Runtime-in-Windows-Container/blob/main/SHIR/build.ps1
+function Install-MSFT-JDK() {
+    Write-Log "Install the Microsoft OpenJDK in the Windows container"
+    Write-Log "Downloading Microsoft OpenJDK 21 LTS msi"
+    $JDKMsiFileName = 'microsoft-jdk-21-windows-x64.msi'
+
+    # Temporarily disable progress updates to speed up the download process. (See https://stackoverflow.com/questions/69942663/invoke-webrequest-progress-becomes-irresponsive-paused-while-downloading-the-fil)
+    $ProgressPreference = 'SilentlyContinue'
+    Invoke-WebRequest -Uri "https://aka.ms/download-jdk/$JDKMsiFileName" -OutFile "C:\SHIR\$JDKMsiFileName"
+    $ProgressPreference = 'Continue'
+
+    Write-Log "Installing Microsoft OpenJDK"
+    # Arguments pulled from https://learn.microsoft.com/en-us/java/openjdk/install#install-via-msi
+    Start-Process msiexec.exe -Wait -ArgumentList "/i C:\SHIR\$JDKMsiFileName ADDLOCAL=FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome INSTALLDIR=`"c:\Program Files\Microsoft\`" /quiet"
+    if (!$?) {
+        Write-Log "Microsoft OpenJDK MSI Install Failed. Trying legacy Java installation."
+        Install-Jre
+    }
+    Write-Log "Microsoft OpenJDK MSI Install Successfully"
+    Write-Log "Will remove C:\SHIR\$JDKMsiFileName"
+    Remove-Item "C:\SHIR\$JDKMsiFileName"
+    Write-Log "Removed C:\SHIR\$JDKMsiFileName"
+}
+
 function SetupEnv() {
     Write-Log "Begin to Setup the SHIR Environment"
     Start-Process $DmgcmdPath -Wait -ArgumentList "-Stop -StopUpgradeService -TurnOffAutoUpdate"
     Write-Log "SHIR Environment Setup Successfully"
 }
 
+function Add-Monitor-User($theUser) {
+    try {
+        Add-LocalGroupMember -Group "Performance Monitor Users" -Member $theUser
+    } catch {
+        Write-Log "The user $theUser was already in the Performance Monitor Users group"
+    }
+    try {
+        Add-LocalGroupMember -Group "Performance Log Users" -Member $theUser
+    } catch {
+        Write-Log "The user $theUser was already in the Performance Log Users group"
+    }
+    Write-Log "The user $theUser is now in groups Performance Monitor Users and Performance Log Users"
+}
+
+function Install-Certificate {
+    $rootcert = (Get-ChildItem -Path C:\SHIR | Where-Object { $_.Name -match [regex] "root.*.cer" })
+    $intermittent = (Get-ChildItem -Path C:\SHIR | Where-Object { $_.Name -match [regex] "intermittent.*.cer" })
+    if($rootcert) {
+        Write-Log "Installing Root Certificate"
+        Import-Certificate -FilePath "C:\SHIR\$rootcert" -CertStoreLocation Cert:\LocalMachine\Root
+        Write-Log "Will remove C:\SHIR\$rootcert"
+        Remove-Item "C:\SHIR\$rootcert"
+
+    }
+    if($intermittent) {
+        Write-Log "Installing Intermittent Certificate"
+        Import-Certificate -FilePath "C:\SHIR\$intermittent" -CertStoreLocation Cert:\LocalMachine\CA
+        Write-Log "Will remove C:\SHIR\$intermittent"
+        Remove-Item "C:\SHIR\$intermittent"
+    }
+}
+
+# Use Install-MSFT-JDK, try to fallback to this if failed to install.
 function Install-Jre() {
     Write-Log "Begin to install the OpenJDK 17 runtime"
     Invoke-WebRequest "https://api.adoptium.net/v3/installer/latest/17/ga/windows/x64/jdk/hotspot/normal/eclipse?project=jdk" -OutFile "C:\SHIR\OpenJdk17.msi"
@@ -86,9 +146,29 @@ function Install-NetFramework() {
 }
 
 try {
-    Install-Jre
-    Install-NetFramework
+    if ([bool]::Parse($env:ADD_MONITOR_USERS)) {
+        Add-Monitor-User "User Manager\ContainerAdministrator"  # This is the user that a user will enter as when logging into the container
+        Add-Monitor-User "NT SERVICE\DIAHostService"            # This is the user that runs the SHIR backend
+    }
+    
+    if ([bool]::Parse($env:INSTALL_JDK)) {
+        Install-MSFT-JDK
+    }
+    if ([bool]::Parse($env:INSTALL_LEGACY_JDK)) {
+        Install-Jre
+    }
+    if ([bool]::Parse($env:INSTALL_NET_FRAMEWORK)) {
+        Install-NetFramework
+    }
+    if ([bool]::Parse($env:INSTALL_CERT)) {
+        Install-Certificate
+    }
+    
     Install-SHIR
+    
+    if ([bool]::Parse($env:SETUP_ENV)) {
+        SetupEnv
+    }
 
 } catch {
     exit 1

--- a/SHIR/build.ps1
+++ b/SHIR/build.ps1
@@ -147,11 +147,6 @@ function Install-NetFramework() {
 }
 
 try {
-    if ([bool]::Parse($env:ADD_MONITOR_USERS)) {
-        Add-Monitor-User "User Manager\ContainerAdministrator"  # This is the user that a user will enter as when logging into the container
-        Add-Monitor-User "NT SERVICE\DIAHostService"            # This is the user that runs the SHIR backend
-    }
-    
     if ([bool]::Parse($env:INSTALL_JDK)) {
         Install-MSFT-JDK
     }
@@ -169,6 +164,10 @@ try {
     
     if ([bool]::Parse($env:SETUP_ENV)) {
         SetupEnv
+    }
+    if ([bool]::Parse($env:ADD_MONITOR_USERS)) {
+        Add-Monitor-User "User Manager\ContainerAdministrator"  # This is the user that a user will enter as when logging into the container
+        Add-Monitor-User "NT SERVICE\DIAHostService"            # This is the user that runs the SHIR backend
     }
 
 } catch {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ variables:
   projectName: 'mi'
   applicationName: 'adf-integration-runtime'
   azureSubscriptionEndpoint: 'DTS-SHAREDSERVICES-PROD'
-  azureContainerRegistry: 'sdshmctspublic.azurecr.io'
+  azureContainerRegistry: 'hmctsprod.azurecr.io'
   ${{ if eq(variables['Build.SourceBranchName'], 'master') }}: 
     deployTarget: prod
     fortifyTarget: stg


### PR DESCRIPTION
Added the following env vars, which can be overridden in the flux configs:

ARG INSTALL_JDK=true
ARG INSTALL_LEGACY_JDK=false
ARG INSTALL_NET_FRAMEWORK=true
ARG INSTALL_CERT=true
ARG ADD_MONITOR_USERS=true
ARG SETUP_ENV=false
ARG SHIR_FIX_VERSION=5.65.9593.1

INSTALL JDK, INSTALL CERT, ADD_MONITOR_USERS are based off the latest microsoft code, using MS Java 21. True by default.
INSTALL_LEGACY_JDK is the existing JDK option, in case the MS JDK doesn't work as expected.
INSTALL_NET_FRAMEWORK makes installing that dependency optional now.
SETUP_ENV already existed but was unused. This allows easily enabling..
SHIR_FIX_VERSION pins to a specific download version.
